### PR TITLE
Changed require to import for the abab dependency.

### DIFF
--- a/src/utils/draw-soccer-jersey.ts
+++ b/src/utils/draw-soccer-jersey.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-const {btoa} = require('abab');
+import {btoa} from 'abab';
 import {Element, Svg, SVG} from '@svgdotjs/svg.js';
 import lightenDarkenColor from './lighten-darken-color';
 import {


### PR DESCRIPTION
This fixes an issue with bundlers in release builds. I have only tested this in my own situation, but as far as I can tell this will not result in unexpected side effects.